### PR TITLE
using GeoJsonHelper in PHP Storm reproduce warning

### DIFF
--- a/helpers/GeoJsonHelper.php
+++ b/helpers/GeoJsonHelper.php
@@ -18,7 +18,7 @@ class GeoJsonHelper
      * @param $type geometry type
      * @param $coordinates array of coordinates
      * @param int $srid SRID
-     * @return json
+     * @return string json
      */
     public static function toGeoJson($type, $coordinates, $srid = 4326)
     {
@@ -43,7 +43,7 @@ class GeoJsonHelper
 
     /**
      * Convert coordinates to Geometry Expression
-     * @param $type geometry type
+     * @param string $type geometry type
      * @param $coordinates array of coordinates
      * @param int $srid SRID
      * @return string


### PR DESCRIPTION
I used in my project on PHP Storm next code:

$ST_GeomFromGeoJSON = GeoJsonHelper::toGeometry(GeometryBehavior::GEOMETRY_POLYGON, $options['request']['polygon']);

PHP Storm reproduce warning: parameter $type  is expected to be geometry type...