### PR TITLE
#8 Added db configuration and lazy getter

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,9 @@ class MyModel extends ActiveRecord
                 'class' => GeometryBehavior::className(),
                 'type' => GeometryBehavior::GEOMETRY_POINT,
                 'attribute' => 'point',
+                // explicitly set custom db connection if you do not want to use
+                // static::getDb() or Yii::$app->getDb() connections
+                'db' => 'db_custom'
             ],
             [
                 'class' => GeometryBehavior::className(),

--- a/behaviors/GeometryBehavior.php
+++ b/behaviors/GeometryBehavior.php
@@ -245,7 +245,10 @@ class GeometryBehavior extends Behavior
     private function _getDb()
     {
         if(empty($this->_db) && !$this->_dbInitialized){
-            if(method_exists($this->owner, 'getDb') && ($db = $this->owner->getDb()) !== null){
+            if ($this->db !== null){
+                 // if db connection is set explicitly, use it
+                 $db = Instance::ensure($this->db, Connection::class);
+            }elseif(method_exists($this->owner, 'getDb') && ($db = $this->owner->getDb()) !== null){
                 // Do not use $this->owner->canGetProperty('db') as $this->owner->db,
                 // since owner can have db attribute, which is not component name
                 // and owner may be not an ActiveRecord instance
@@ -255,9 +258,6 @@ class GeometryBehavior extends Behavior
                 if((is_string($db) || is_array($db) || is_callable($db)) && !$db instanceof Connection){
                     $db = Instance::ensure($db, Connection::class);
                 }
-            }elseif ($this->db !== null){
-                // if owner does not provide db connection, the use defined fallback
-                $db = Instance::ensure($this->db, Connection::class);
             }else{
                 // do not execute the following code, since db component may change during app lifecycle and
                 // we want to respect such behavior

--- a/composer.json
+++ b/composer.json
@@ -28,11 +28,5 @@
     "psr-4": {
       "nanson\\postgis\\": ""
     }
-  },
-  "repositories": [
-    {
-      "type": "composer",
-      "url": "https://asset-packagist.org"
-    }
-  ]
+  }
 }

--- a/composer.json
+++ b/composer.json
@@ -28,5 +28,11 @@
     "psr-4": {
       "nanson\\postgis\\": ""
     }
-  }
+  },
+  "repositories": [
+    {
+      "type": "composer",
+      "url": "https://asset-packagist.org"
+    }
+  ]
 }


### PR DESCRIPTION
Since there is no tests in original repo, neither in mine.
Checked at my project:

1. attached behavior to AR class - AR::getDb() is used, 
1. attached behavior to AR class - and explicitly set db property - property used, 
2. attached behavior to Component and explicitly set db property for behavior - worked
3. attached behavior to Component class which has db property but don't have getDb method - Yii::$app->getDb() is used.