### PR TITLE
Update GeometryBehavior.php

### DIFF
--- a/behaviors/GeometryBehavior.php
+++ b/behaviors/GeometryBehavior.php
@@ -48,7 +48,13 @@ class GeometryBehavior extends Behavior
      * @var string geometry name
      */
     public $type;
+    
+    /**
+     * @var string srid number
+     */
+    public $srid;
 
+    /**
     /**
      * @var bool don't convert attribute afterFind if it in Postgis binary format (it requires a separate query)
      */
@@ -188,7 +194,7 @@ class GeometryBehavior extends Behavior
 
         if (!empty($coordinates)) {
 
-            $query = is_array($coordinates) ? GeoJsonHelper::toGeometry($this->type, $coordinates) : "'$coordinates'";
+            $query = is_array($coordinates) ? GeoJsonHelper::toGeometry($this->type, $coordinates, $this->srid) : "'$coordinates'";
 
             $this->owner->{$this->attribute} = new Expression($query);
         } else {


### PR DESCRIPTION
Hi,

 I had an error with the plugin when it did an insert. This was due to my layer in PostGIS not being in 4326 (was using a local Australian national coordinate system). So I propose adding the srid as an option and then it can be passed into the GeoJsonHelper::toGeometry function as the third paramater.

then in the model I can do something like:

  [
                'class' => GeometryBehavior::className(),
                'type' => GeometryBehavior::GEOMETRY_POINT,
                'attribute' => 'geom',
                'srid'=>'4283'
                ]

Thanks